### PR TITLE
update build settings to 'ng test' can run without error

### DIFF
--- a/aspnet-core-angular/angular/angular.json
+++ b/aspnet-core-angular/angular/angular.json
@@ -139,6 +139,7 @@
             "main": "src/test.ts",
             "karmaConfig": "./karma.conf.js",
             "polyfills": "src/polyfills.ts",
+            "tsConfig": "src/tsconfig.json",            
             "scripts": [
               "node_modules/jquery/dist/jquery.min.js",
               "node_modules/jquery-migrate/dist/jquery-migrate.min.js",


### PR DESCRIPTION
This amend will allow 'ng test' to run without error.

Without this setting, 'ng test' will fail as it cannot find tsconfig.json