### PR TITLE
Upgrade to ABP 9.1

### DIFF
--- a/angular/src/shared/auth/app-auth.service.ts
+++ b/angular/src/shared/auth/app-auth.service.ts
@@ -31,7 +31,7 @@ export class AppAuthService {
         abp.utils.deleteCookie(AppConsts.authorization.encryptedAuthTokenName);
         
         if (reload !== false) {
-            location.href = AppConsts.appBaseUrl + 'index.html';
+            location.href = AppConsts.appBaseUrl + '/index.html';
         }
     }
 
@@ -92,7 +92,7 @@ export class AppAuthService {
 
         let initialUrl = UrlHelper.initialUrl;
         if (initialUrl.indexOf('/login') > 0) {
-            initialUrl = AppConsts.appBaseUrl + 'index.html';
+            initialUrl = AppConsts.appBaseUrl + '/index.html';
         }
 
         location.href = initialUrl;

--- a/aspnet-core/src/EventCloud.Application/Events/EventAppService.cs
+++ b/aspnet-core/src/EventCloud.Application/Events/EventAppService.cs
@@ -61,7 +61,7 @@ namespace EventCloud.Events
 
         public async Task CreateAsync(CreateEventInput input)
         {
-            var tenantId = (int)AbpSession.TenantId.Value;
+            var tenantId = AbpSession.TenantId.Value;
             var @event = Event.Create(tenantId, input.Title, input.Date, input.Description, input.MaxRegistrationCount);
             await _eventManager.CreateAsync(@event);
         }

--- a/aspnet-core/src/EventCloud.Core/Authorization/EventCloudAuthorizationProvider.cs
+++ b/aspnet-core/src/EventCloud.Core/Authorization/EventCloudAuthorizationProvider.cs
@@ -11,7 +11,7 @@ namespace EventCloud.Authorization
             context.CreatePermission(PermissionNames.Pages_Users, L("Users"));
             context.CreatePermission(PermissionNames.Pages_Users_Activation, L("UsersActivation"));
             context.CreatePermission(PermissionNames.Pages_Roles, L("Roles"));
-            context.CreatePermission(PermissionNames.Pages_Events, L("Roles"));
+            context.CreatePermission(PermissionNames.Pages_Events, L("Events"), multiTenancySides: MultiTenancySides.Tenant);
             context.CreatePermission(PermissionNames.Pages_Tenants, L("Tenants"), multiTenancySides: MultiTenancySides.Host);
         }
 

--- a/aspnet-core/src/EventCloud.Core/EventCloud.Core.csproj
+++ b/aspnet-core/src/EventCloud.Core/EventCloud.Core.csproj
@@ -15,8 +15,8 @@
     <EmbeddedResource Include="Localization\SourceFiles\*.xml" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Abp.AutoMapper" Version="9.0.0" />
-    <PackageReference Include="Abp.ZeroCore.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Abp.AutoMapper" Version="9.1.0" />
+    <PackageReference Include="Abp.ZeroCore.EntityFrameworkCore" Version="9.1.0" />
     <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="4.1.0" />
   </ItemGroup>
 </Project>

--- a/aspnet-core/src/EventCloud.Core/Identity/SecurityStampValidator.cs
+++ b/aspnet-core/src/EventCloud.Core/Identity/SecurityStampValidator.cs
@@ -15,10 +15,9 @@ namespace EventCloud.Identity
         public SecurityStampValidator(
             IOptions<SecurityStampValidatorOptions> options,
             SignInManager signInManager,
-            ISystemClock systemClock,
             ILoggerFactory loggerFactory,
             IUnitOfWorkManager unitOfWorkManager)
-            : base(options, signInManager, systemClock, loggerFactory, unitOfWorkManager)
+            : base(options, signInManager, loggerFactory, unitOfWorkManager)
         {
         }
     }

--- a/aspnet-core/src/EventCloud.EntityFrameworkCore/EventCloud.EntityFrameworkCore.csproj
+++ b/aspnet-core/src/EventCloud.EntityFrameworkCore/EventCloud.EntityFrameworkCore.csproj
@@ -13,12 +13,12 @@
     <Compile Remove="Migrations\20190111071724_Upgraded_To_Abp_v4_1_0.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/aspnet-core/src/EventCloud.Migrator/EventCloud.Migrator.csproj
+++ b/aspnet-core/src/EventCloud.Migrator/EventCloud.Migrator.csproj
@@ -15,7 +15,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Abp.Castle.Log4Net" Version="9.0.0" />
+    <PackageReference Include="Abp.Castle.Log4Net" Version="9.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventCloud.Core\EventCloud.Core.csproj" />

--- a/aspnet-core/src/EventCloud.Web.Core/EventCloud.Web.Core.csproj
+++ b/aspnet-core/src/EventCloud.Web.Core/EventCloud.Web.Core.csproj
@@ -23,10 +23,10 @@
     <ProjectReference Include="..\EventCloud.EntityFrameworkCore\EventCloud.EntityFrameworkCore.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="Abp.AspNetCore" Version="9.0.0" />
-    <PackageReference Include="Abp.ZeroCore" Version="9.0.0" />
-    <PackageReference Include="Abp.AspNetCore.SignalR" Version="9.0.0" />
+    <PackageReference Include="Abp.AspNetCore" Version="9.1.0" />
+    <PackageReference Include="Abp.ZeroCore" Version="9.1.0" />
+    <PackageReference Include="Abp.AspNetCore.SignalR" Version="9.1.0" />
   </ItemGroup>
 </Project>

--- a/aspnet-core/src/EventCloud.Web.Host/EventCloud.Web.Host.csproj
+++ b/aspnet-core/src/EventCloud.Web.Host/EventCloud.Web.Host.csproj
@@ -32,8 +32,8 @@
     <ProjectReference Include="..\EventCloud.Web.Core\EventCloud.Web.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Abp.Castle.Log4Net" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+    <PackageReference Include="Abp.Castle.Log4Net" Version="9.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/aspnet-core/src/EventCloud.Web.Host/Startup/Startup.cs
+++ b/aspnet-core/src/EventCloud.Web.Host/Startup/Startup.cs
@@ -1,25 +1,22 @@
-﻿using System;
-using System.Linq;
-using System.Reflection;
+﻿using Abp.AspNetCore;
+using Abp.AspNetCore.Mvc.Antiforgery;
+using Abp.AspNetCore.SignalR.Hubs;
+using Abp.Castle.Logging.Log4Net;
+using Abp.Extensions;
+using Castle.Facilities.Logging;
+using EventCloud.Configuration;
+using EventCloud.Identity;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Castle.Facilities.Logging;
-using Abp.AspNetCore;
-using Abp.AspNetCore.Mvc.Antiforgery;
-using Abp.Castle.Logging.Log4Net;
-using Abp.Extensions;
-using EventCloud.Configuration;
-using EventCloud.Identity;
-using Abp.AspNetCore.SignalR.Hubs;
-using Abp.Dependency;
-using Abp.Json;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
-using Newtonsoft.Json.Serialization;
+using System;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 
 namespace EventCloud.Web.Host.Startup
 {
@@ -41,14 +38,9 @@ namespace EventCloud.Web.Host.Startup
         public void ConfigureServices(IServiceCollection services)
         {
             //MVC
-            services.AddControllersWithViews(
-                options => { options.Filters.Add(new AbpAutoValidateAntiforgeryTokenAttribute()); }
-            ).AddNewtonsoftJson(options =>
+            services.AddControllersWithViews(options =>
             {
-                options.SerializerSettings.ContractResolver = new AbpMvcContractResolver(IocManager.Instance)
-                {
-                    NamingStrategy = new CamelCaseNamingStrategy()
-                };
+                options.Filters.Add(new AbpAutoValidateAntiforgeryTokenAttribute());
             });
 
             IdentityRegistrar.Register(services);

--- a/aspnet-core/test/EventCloud.Tests/EventCloud.Tests.csproj
+++ b/aspnet-core/test/EventCloud.Tests/EventCloud.Tests.csproj
@@ -24,8 +24,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Abp.TestBase" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Abp.TestBase" Version="9.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.1" />
     <PackageReference Include="Castle.Core" Version="5.1.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Resolves [aspnetboilerplate/issues/6879](https://github.com/aspnetboilerplate/aspnetboilerplate/issues/6879)

ABP 9.1 has been upgraded. Event permission has been modified, and the Event host is now hidden by default.